### PR TITLE
[FIX] Play 2.6 - DI compile time

### DIFF
--- a/src/main/scala/com/marcospereira/play/i18n/HoconMessagesApi.scala
+++ b/src/main/scala/com/marcospereira/play/i18n/HoconMessagesApi.scala
@@ -106,12 +106,12 @@ class HoconI18nModule extends Module {
 /**
  * Components for Compile Time Dependency Injection.
  */
-trait HoconI18nComponents {
+trait HoconI18nComponents extends I18nComponents {
 
   def environment: Environment
   def configuration: Configuration
   def httpConfiguration: HttpConfiguration
   def langs: Langs
 
-  lazy val messagesApi: MessagesApi = new HoconMessagesApiProvider(environment, configuration, langs, httpConfiguration).get
+  override lazy val messagesApi: MessagesApi = new HoconMessagesApiProvider(environment, configuration, langs, httpConfiguration).get
 }


### PR DESCRIPTION
**Current behavior**

When extending the `HoconI18nComponents`:

```
class CustomComponents(
  context: ApplicationLoader.Context
) extends BuiltInComponentsFromContext(context)
     with HoconI18nComponents
     with AssetsComponents {
  ...
}
```

```
[error] [...]/CustomApplicationLoader.scala:26: class CustomComponents inherits conflicting members:
[error]   lazy value messagesApi in trait I18nComponents of type play.api.i18n.MessagesApi  and
[error]   lazy value messagesApi in trait HoconI18nComponents of type play.api.i18n.MessagesApi
```
**Expected behavior:**

When extending the `HoconI18nComponents`: to compile out of the box.

**Solution**:

Override messagesApi since I18nComponents is extended by BuiltInComponents in Play 2.6.